### PR TITLE
upgrade ODBC driver to version 17.10

### DIFF
--- a/7.4-nginx-sqlsrv-prod/Dockerfile
+++ b/7.4-nginx-sqlsrv-prod/Dockerfile
@@ -4,11 +4,11 @@ FROM kooldev/php:7.4-nginx-prod
 
 RUN set -xe \
     # Download the desired package(s)
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.2.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.10.1.1-1_amd64.apk \
     #Install the package(s)
-    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk \
-    && apk add --allow-untrusted mssql-tools_17.7.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql17_17.10.2.1-1_amd64.apk \
+    && apk add --allow-untrusted mssql-tools_17.10.1.1-1_amd64.apk \
     && apk add --no-cache --virtual .persistent-deps freetds unixodbc \
     && apk add --no-cache --virtual .build-deps $PHPIZE_DEPS unixodbc-dev freetds-dev \
     && docker-php-source extract \

--- a/7.4-nginx-sqlsrv/Dockerfile
+++ b/7.4-nginx-sqlsrv/Dockerfile
@@ -4,11 +4,11 @@ FROM kooldev/php:7.4-nginx
 
 RUN set -xe \
     # Download the desired package(s)
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.2.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.10.1.1-1_amd64.apk \
     #Install the package(s)
-    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk \
-    && apk add --allow-untrusted mssql-tools_17.7.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql17_17.10.2.1-1_amd64.apk \
+    && apk add --allow-untrusted mssql-tools_17.10.1.1-1_amd64.apk \
     && apk add --no-cache --virtual .persistent-deps freetds unixodbc \
     && apk add --no-cache --virtual .build-deps $PHPIZE_DEPS unixodbc-dev freetds-dev \
     && docker-php-source extract \

--- a/8.1-nginx-sqlsrv-prod/Dockerfile
+++ b/8.1-nginx-sqlsrv-prod/Dockerfile
@@ -4,11 +4,11 @@ FROM kooldev/php:8.1-nginx-prod
 
 RUN set -xe \
     # Download the desired package(s)
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.2.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.10.1.1-1_amd64.apk \
     #Install the package(s)
-    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk \
-    && apk add --allow-untrusted mssql-tools_17.7.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql17_17.10.2.1-1_amd64.apk \
+    && apk add --allow-untrusted mssql-tools_17.10.1.1-1_amd64.apk \
     && apk add --no-cache --virtual .persistent-deps freetds unixodbc \
     && apk add --no-cache --virtual .build-deps $PHPIZE_DEPS unixodbc-dev freetds-dev \
     && docker-php-source extract \

--- a/8.1-nginx-sqlsrv/Dockerfile
+++ b/8.1-nginx-sqlsrv/Dockerfile
@@ -4,11 +4,11 @@ FROM kooldev/php:8.1-nginx
 
 RUN set -xe \
     # Download the desired package(s)
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.2.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.10.1.1-1_amd64.apk \
     #Install the package(s)
-    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk \
-    && apk add --allow-untrusted mssql-tools_17.7.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql17_17.10.2.1-1_amd64.apk \
+    && apk add --allow-untrusted mssql-tools_17.10.1.1-1_amd64.apk \
     && apk add --no-cache --virtual .persistent-deps freetds unixodbc \
     && apk add --no-cache --virtual .build-deps $PHPIZE_DEPS unixodbc-dev freetds-dev \
     && docker-php-source extract \

--- a/template/Dockerfile.blade.php
+++ b/template/Dockerfile.blade.php
@@ -4,11 +4,11 @@ FROM {{ $from }}
 
 RUN set -xe \
     # Download the desired package(s)
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.2.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.10.1.1-1_amd64.apk \
     #Install the package(s)
-    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk \
-    && apk add --allow-untrusted mssql-tools_17.7.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql17_17.10.2.1-1_amd64.apk \
+    && apk add --allow-untrusted mssql-tools_17.10.1.1-1_amd64.apk \
     && apk add --no-cache --virtual .persistent-deps freetds unixodbc \
     && apk add --no-cache --virtual .build-deps $PHPIZE_DEPS unixodbc-dev freetds-dev \
     && docker-php-source extract \


### PR DESCRIPTION
Using the current ODBC driver version (17.7) we had problems connecting to SQL Server using php8.1 images.

The php8.1 images, use OpenSSL v3, but the current ODBC driver doesn't support this version. After upgrading to v17.10 we were able to connect to SQL Server again.

The new version I'm proposing works well with both PHP images, 7.4 and 8.1.